### PR TITLE
Update checksum and point to SNAPSHOT instead of latest

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,7 +27,7 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 id      = "riff-invoker-node"
 name    = "riff Node Invoker"
 version = "0.2.0+snapshot"
-uri     = "https://storage.googleapis.com/projectriff/node-function-invoker/releases/v0.2.0-snapshot/node-function-invoker-0.2.0-snapshot.tgz"
+uri     = "https://storage.googleapis.com/projectriff/node-function-invoker/releases/v0.2.0-snapshot/snapshots/node-function-invoker-0.2.0-snapshot-4d6e965455c58b609e631ff7627823516e6d87c3.tgz"
 sha256  = "9b1e2eeaca39965daf382ba2dc3cd3e84960c0bc2326d21f534ec079868c190f"
 stacks  = [
   "io.buildpacks.stacks.bionic",

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,8 +27,8 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 id      = "riff-invoker-node"
 name    = "riff Node Invoker"
 version = "0.2.0+snapshot"
-uri     = "https://storage.googleapis.com/projectriff/node-function-invoker/releases/latest/node-function-invoker.tgz"
-sha256  = "ba6a2fbac08ee4969d3288eec08ded2b7e38a427c70d52d76074912a050316ee"
+uri     = "https://storage.googleapis.com/projectriff/node-function-invoker/releases/v0.2.0-snapshot/node-function-invoker-0.2.0-snapshot.tgz"
+sha256  = "9b1e2eeaca39965daf382ba2dc3cd3e84960c0bc2326d21f534ec079868c190f"
 stacks  = [
   "io.buildpacks.stacks.bionic",
   "org.cloudfoundry.stacks.cflinuxfs3",


### PR DESCRIPTION
Since the checksum keeps changing, pointing to latest is pointless

The SNAPSHOT includes https://github.com/projectriff/node-function-invoker/commit/4d6e965455c58b609e631ff7627823516e6d87c3