### PR TITLE
Add heroku-18 as a supported stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,13 +25,16 @@ id = "io.buildpacks.stacks.bionic"
 [[stacks]]
 id = "org.cloudfoundry.stacks.cflinuxfs3"
 
+[[stacks]]
+id = "heroku-18"
+
 [[metadata.dependencies]]
 id      = "riff-invoker-node"
 name    = "riff Node Invoker"
 version = "0.2.0+snapshot"
 uri     = "https://storage.googleapis.com/projectriff/node-function-invoker/releases/v0.2.0-snapshot/snapshots/node-function-invoker-0.2.0-snapshot-2883a0cf551be1f58d1605484ebf285d1b47b268.tgz"
 sha256  = "1ba3812d8dfeb0cfbb6c6d28dcad917446a5a5a2868352ad723e3d8aec744f87"
-stacks  = [ "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3" ]
+stacks  = [ "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3", "heroku-18" ]
 
   [[metadata.dependencies.licenses]]
   type = "Apache-2.0"
@@ -43,7 +46,7 @@ name    = "riff Streaming HTTP Adapter"
 version = "0.1.0+snapshot"
 uri     = "https://storage.googleapis.com/projectriff/streaming-http-adapter/streaming-http-adapter-linux-amd64-0.1.0-snapshot-20200116111801-335efae9e9ffd5db.tgz"
 sha256  = "c43bd5473ac9d5878b4561ef1aecf071a047d5cba05daef25c834662776eee3f"
-stacks  = [ "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3" ]
+stacks  = [ "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3", "heroku-18" ]
 
   [[metadata.dependencies.licenses]]
   type = "Apache-2.0"


### PR DESCRIPTION
It would be nice to support another `bionic` based stack to prevent Heroku from forking all the language buildpacks.

Note: While [this RFC](https://github.com/buildpacks/rfcs/pull/40) is being discussed, it hasn't landed yet.