### PR TITLE
Adds buildpack homepage

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,6 +18,7 @@ api = "0.2"
 id = "io.projectriff.node"
 name = "Node Function Buildpack"
 version = "0.3.1-BUILD-SNAPSHOT"
+homepage = "https://github.com/projectriff/node-function-buildpack"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
The next version of `pack` will support buildpack homepages

https://github.com/buildpacks/rfcs/blob/master/text/0030-links-for-buildpacks.md